### PR TITLE
Add __() function completion

### DIFF
--- a/WP-Functions-Completions.sublime-completions
+++ b/WP-Functions-Completions.sublime-completions
@@ -3,6 +3,7 @@
 	"comment": "WP Functions",
 	"completions":
 	[
+	{"trigger": "__", "contents": "__( '${1:text}'${2:, '${3:domain}'} )"},
 	{"trigger": "__checked_selected_helper", "contents": "__checked_selected_helper(${1: ${2:\\$helper}, ${3:\\$current}, ${4:\\$echo}, ${5:\\$type}} );"},
 	{"trigger": "__clear_multi_author_cache", "contents": "__clear_multi_author_cache();"},
 	{"trigger": "__return_empty_array", "contents": "__return_empty_array();"},


### PR DESCRIPTION
- The arguments for `__()` are both text strings, so single quotes are added around the placeholders.
- The first argument is required, so making all arguments optional is incorrect. The second argument is optional though, so the second placeholder is around the comma, space and quoted third placeholder.
- The trailing semi-colon is left off. This only applies when the function is at the end of the string, yet it is more likely to be used inside another function such as `printf()` or `sprintf()`, or as an array item requiring a trailing comma, or as part of a concatenated string.
