### PR TITLE
Add file head snippet.

### DIFF
--- a/Snippets/File_Head.sublime-snippet
+++ b/Snippets/File_Head.sublime-snippet
@@ -17,5 +17,5 @@
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	 <tabTrigger>file_head</tabTrigger>
 	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>source.php - variable.other.php</scope>
+    <!--<scope>source.php - variable.other.php</scope>-->
 </snippet>


### PR DESCRIPTION
Add an additional File_Head snippet to add for sub-files on themes and plugins. Includes suggested tags from https://make.wordpress.org/core/handbook/inline-documentation-standards/php-documentation-standards/#6-file-headers
